### PR TITLE
FIX: Remove invalid parameters default and type for arm credentials

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -27,13 +27,9 @@ on:
       ARM_USERNAME:
         description: 'Username for the ARM Data Discovery portal (https://adc.arm.gov/armlive/)'
         required: false
-        default: ''
-        type: string
       ARM_PASSWORD:
         description: 'Password for the ARM Data Discovery portal (https://adc.arm.gov/armlive/)'
         required: false
-        default: ''
-        type: string
 
 jobs:
   build:


### PR DESCRIPTION
Secrets do not allow passing the type and default values.

See https://github.com/ProjectPythiaCookbooks/radar-cookbook/actions/runs/3053946245

This removes those parameters from the secrets