### PR TITLE
Add destination-dir option

### DIFF
--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -2,6 +2,12 @@ name: deploy-book
 
 on:
   workflow_call:
+    inputs:
+      destination_dir:
+        description: 'Path to publish to on GitHub Pages, relative to site root. We use this to deploy previews in a subdirectory.'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   deploy:
@@ -29,3 +35,4 @@ jobs:
           publish_dir: _build/html
           enable_jekyll: false
           keep_files: true  # This preserves existing previews from open PRs
+          destination_dir: ${{ inputs.destination_dir }}


### PR DESCRIPTION
This makes the `deploy-book.yaml` reusable workflow more general. We should be able to use it at least twice for every PR: once to deploy the preview, and once to deploy the final result.

It will be the responsibility of the calling workflow to provide the right path for the preview as input argument `destination_dir`.