### PR TITLE
Add optional cname argument for deploy

### DIFF
--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -18,6 +18,11 @@ on:
         required: false
         default: 'false'
         type: string
+      cname:
+        description: 'Custom domain name'
+        required: false
+        default: 'None'  # This is just a flag for whether to ignore this input
+        type: string
       
 jobs:
   deploy:
@@ -51,10 +56,25 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3.9.0
-        if: github.ref == 'refs/heads/main'
+        if: |
+          (github.ref == 'refs/heads/main'
+          && inputs.cname == 'None')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html
           enable_jekyll: false
           keep_files: true  # This preserves existing previews from open PRs
           destination_dir: ${{ inputs.destination_dir }}
+
+      - name: Deploy to GitHub Pages with custom domain
+        uses: peaceiris/actions-gh-pages@v3.9.0
+        if: |
+          (github.ref == 'refs/heads/main'
+          && inputs.cname != 'None')
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html
+          enable_jekyll: false
+          keep_files: true  # This preserves existing previews from open PRs
+          destination_dir: ${{ inputs.destination_dir }}
+          cname: ${{ inputs.cname }}


### PR DESCRIPTION
This is needed to use this infrastructure to publish Pythia Foundations, which needs a custom CNAME when deployed to GitHub Pages.

Should be fully backwards compatible, but can't actually test without merging (an example of why #6 is needed).