### PR TITLE
Use micromamba to install full environment

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -42,19 +42,11 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup environment with micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: ${{ inputs.environment_file }}
-
-      # - name: Setup Miniforge
-      #   uses: conda-incubator/setup-miniconda@v3
-      #   with:
-      #     miniforge-version: latest
-
-      # - name: Install Jupyterbook
-      #   run: conda install -c conda-forge jupyter-book "python<3.13"  # see https://github.com/ProjectPythia/cookbook-actions/issues/126
 
       - name: Check for config file
         id: check_config


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR switches the link-checker.yaml workflow over to micromamba to install the full environment described in the environment file of the calling repository. Previously we ignored the environment and just hard-coded an installation of JupyterBook to run the link checker for performance reasons. Micromamba is so fast that this is no longer needed, and it's better to let each repo specify its own link-checker environment.