### PR TITLE
Update default build command to include --strict

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -26,7 +26,7 @@ on:
       build_command:
         description: 'The linux command to build the book or site.'
         required: false
-        default: 'myst build --execute --html'
+        default: 'myst build --execute --html --strict'
         type: string
       output_path:
         description: 'Path to the built html content relative to `path_to_notebooks`'


### PR DESCRIPTION
Per https://github.com/jupyter-book/mystmd/issues/2113 and https://github.com/ProjectPythia/cookbook-actions/issues/150

Not sure if there is a way to let individual cookbooks revert back to the default if they want it to build with failing cells. Previously this was done in each configuration file, but we would need to update the action in that individual repository? Potential solution - https://mystmd.org/guide/settings#error-rules 