### PR TITLE
feat: setup action to use clinder

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -158,7 +158,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ inputs.path_to_notebooks }}/_build/execute
-          key: ${{ runner.os }}-${{ inputs.path_to_notebooks }}-${{ inputs.build_command }}-execution
+          key: ${{ runner.os }}-${{ hashFiles(inputs.environment_file) }}-${{ inputs.path_to_notebooks }}-${{ inputs.build_command }}-execution
       - name: Build the book
         env:
           # TODO: provision remote environment with secrets, e.g. https://github.com/agoose77/jupyter-environment-provisioner


### PR DESCRIPTION
Following from the [Statement of Work] that 2i2c have authored to build out a replacement for BinderBot, this PR sets up the build action to use the https://github.com/2i2c-org/clinder action. It makes the following changes:

- Drops search for `_config.yml`. Presently uses action inputs to control e.g. whether to use BinderHub
- Breaks environment variable passing to BinderHub. I have suggestions for this, but I think one step at a time.

The new action simply sets up a BinderHub session and exposes it to the action runner via environment variables (by default). The MyST Document Engine is natively aware of these, and will use them to find the Jupyter Server instead of launching a local one.

I'm testing this over at https://github.com/ProjectPythia/ptype-ml-clinder-test

> [!Note]
> I had some trouble migrating existing repositories — it seems that most cookbooks are broken in one way, or otherwise need environment variables.

[statement of work]: https://hackmd.io/MLH7Syq3Sa6lfeNUTuJIBQ