### PR TITLE
Upload full zipped book directory

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -259,9 +259,16 @@ jobs:
               rm -rf book.zip
           fi
           zip -r book.zip ${{ inputs.path_to_notebooks }}/${{ inputs.output_path }}
+          zip -r full-book.zip ${{ inputs.path_to_notebooks }}
 
-      - name: Upload zipped book artifact
+      - name: Upload zipped rendered book artifact
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_name }}
           path: ./book.zip
+
+      - name: Upload zipped full book artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs.artifact_name }}-full
+          path: ./full-book.zip


### PR DESCRIPTION
This includes the execution cache and the built HTML as well, which helps us render books in other rendering systems (like https://jupyterbook.pub).

Eventually we can probably just ship the notebooks + executed outputs once https://github.com/jupyter-book/mystmd/issues/2688#issuecomment-3899263054 lands
