### PR TITLE
Turn off strict building

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -26,7 +26,7 @@ on:
       build_command:
         description: 'The linux command to build the book or site.'
         required: false
-        default: 'myst build --execute --html --strict'
+        default: 'myst build --execute --html'
         type: string
       output_path:
         description: 'Path to the built html content relative to `path_to_notebooks`'

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -28,33 +28,6 @@ on:
         required: false
         default: '_build/html'
         type: string
-  workflow_dispatch:
-    inputs:
-      artifact_name:
-        description: 'Name of the artifact (zipped book) created by previous build step'
-        required: false
-        default: book-zip
-        type: string
-      destination_dir:
-        description: 'Path to publish to on GitHub Pages, relative to site root. We use this to deploy previews in a subdirectory.'
-        required: false
-        default: ''
-        type: string
-      is_preview:
-        description: 'Are we deploying a preview?'
-        required: false
-        default: 'false'
-        type: string
-      cname:
-        description: 'Custom domain name'
-        required: false
-        default: 'None'  # This is just a flag for whether to ignore this input
-        type: string
-      publish_dir:
-        description: 'Publish dir for the action'
-        required: false
-        default: '_build/html'
-        type: string
       
 jobs:
   deploy:

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -29,6 +29,32 @@ on:
         default: '_build/html'
         type: string
   workflow_dispatch:
+    inputs:
+      artifact_name:
+        description: 'Name of the artifact (zipped book) created by previous build step'
+        required: false
+        default: book-zip
+        type: string
+      destination_dir:
+        description: 'Path to publish to on GitHub Pages, relative to site root. We use this to deploy previews in a subdirectory.'
+        required: false
+        default: ''
+        type: string
+      is_preview:
+        description: 'Are we deploying a preview?'
+        required: false
+        default: 'false'
+        type: string
+      cname:
+        description: 'Custom domain name'
+        required: false
+        default: 'None'  # This is just a flag for whether to ignore this input
+        type: string
+      publish_dir:
+        description: 'Publish dir for the action'
+        required: false
+        default: '_build/html'
+        type: string
       
 jobs:
   deploy:

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -28,6 +28,7 @@ on:
         required: false
         default: '_build/html'
         type: string
+  workflow_dispatch:
       
 jobs:
   deploy:


### PR DESCRIPTION
As discussed in today's community meeting.

Strict building is hanging (especially on link checks) too frequently. We are temporarily turning it off in hopes of reducing our action minutes while we establish a solution (upstream on MyST hopefully) that separates links from notebook execution. 