### PR TITLE
Add timeout to all `build` jobs

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -92,6 +92,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -leo pipefail {0}


### PR DESCRIPTION
This is the simplest version of this, and will cause all `build` jobs to be cancelled after `timeout-minutes`, currently 30. We can make this configurable or change the threshold if we prefer, but we should have _something_ here right now, as long as non-fail hangups from MyST are still a possibility.

This may not always be necessary.