### PR TITLE
Skip all separate linkcheck jobs

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   link-checker:
+    if: false
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Another lazy quickfix. This time we can skip all linkcheck jobs while keeping the stub workflows in place. Glad to plan bigger changes or leave this out. But if we want them turned off for now, this gets us there.