### PR TITLE
MERGING ASAP: Limit linkcheck to 10 mins

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -37,6 +37,7 @@ concurrency:
 jobs:
   link-checker:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Regardless of linkchecking without `--strict`-induced failures, we have a few linkchecks hanging runs at 6h again. Limit these if we insist on running them for now.

<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
