### PR TITLE
Add new validator for `myst.yml`

### DIFF
--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -1,14 +1,15 @@
-name: validate-config
+name: Validate myst.yml
 
 on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}=${{ github.head_ref}}
+  group: ${{ github.workflow }}-${{ github.head_ref}}
   cancel-in-progress: true
 
 jobs:
-  build:
+  validate:
+    name: Run validator
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -1,0 +1,28 @@
+name: validate-config
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}=${{ github.head_ref}}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: ProjectPythia/cookbook-actions
+          ref: feat/clinder
+          sparse-checkout: |
+            myst.schema.json
+          sparse-checkout-cone-mode: false
+      - name: Run myst.yml validator
+        run: |
+          npx --yes ajv-cli \
+            validate \
+            -s myst.schema.json \
+            -d myst.yml \
+            --spec=draft2020

--- a/myst.schema.json
+++ b/myst.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/projectpythia/pythia-config/myst.schema.json",
+  "$ref": "#/definitions/myst.yml",
+  "definitions": {
+    "myst.yml": {
+      "type": "object",
+      "required": ["project"],
+      "properties": {
+        "project": {
+          "$ref": "#/definitions/project"
+        }
+      }
+    },
+    "cookbook-tag": {
+      "type": "string",
+      "enum": ["cookbook:build-on-binder"]
+    },
+    "project": {
+      "type": "object",
+      "required": ["title", "thumbnail", "tags"],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "thumbnail": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "$comment": "Ifn we have a `cookbook:` tag prefix, require that it validates",
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/cookbook-tag" },
+              {
+                "not": {
+                  "type": "string",
+                  "pattern": "^cookbook:.*"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR extracts the `myst.yml` validation from #167 into a separate PR. 

The goal is to introduce an action to validate cookbooks against a schema. This schema ensures that we can add configuration and metadata to generic `myst.yml` config that is specific to Pythia.

Each cookbook will need to migrate, over time, to add support for this configuration instead of using `_gallery_info.yml`.

The motivation for this PR is to be able to use `myst.yml#project.tags` to specify boolean config like "use BinderHub". This ensures that we don't need a second config file, and also that this information is exposed in the MyST build itself.